### PR TITLE
Incorrect iconUrl location

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -19,10 +19,11 @@ export function getAstroLeafletMarkerDefaultIcon() {
       iconAnchor: [12, 41],
       popupAnchor: [2, -40],
       iconRetinaUrl: 'https://unpkg.com/leaflet@1.9.0/dist/images/marker-icon-2x.png',
-      iconUrl: 'https://unpkg.com/leaflet@1.9.0/dist/images/marker-shadow.png',
+      iconUrl: 'https://unpkg.com/leaflet@1.9.0/dist/images/marker-icon.png',
       shadowUrl: 'https://unpkg.com/leaflet@1.9.0/dist/images/marker-shadow.png',
     })
   }
 
   return _astroLeafletMarkerDefaultIcon
 }
+


### PR DESCRIPTION
The iconUrl points to marker-shadow.png instead of marker-icon.png. This patch correct the error.